### PR TITLE
기기 재등록 시 오류 수정#132

### DIFF
--- a/b_end/src/mqtt/mqtt.controller.ts
+++ b/b_end/src/mqtt/mqtt.controller.ts
@@ -18,6 +18,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -71,6 +72,9 @@ export class MqttController {
   @ApiCreatedResponse({ description: '성공적으로 등록 시, Created 상태 반환' })
   @ApiUnauthorizedResponse({
     description: '권한이 없는 요청에 대해 UnAuthentication 반환',
+  })
+  @ApiConflictResponse({
+    description: '이미 존재하는 기기 등록 시 409 상태코드 반환',
   })
   @Post('device')
   async register(@GetUser() user, @Body('device') device) {

--- a/b_end/src/mqtt/mqtt.service.ts
+++ b/b_end/src/mqtt/mqtt.service.ts
@@ -106,8 +106,7 @@ export class MqttService implements OnModuleInit {
         },
       });
     } catch (e) {
-      console.error(e);
-      return HttpStatus.NOT_FOUND;
+      throw new HttpException('Exist Relation', HttpStatus.CONFLICT);
     }
 
     this.client.subscribe(`${deviceName}/#`, (err) => {


### PR DESCRIPTION
## Summary

- 이미 존재하는 기기를 재등록할 때, 서버가 다운되는 문제

<br>

## Description

- CONFLICT Exception을 발생시키고 전역 필터에서 처리되도록 함.

<br>

## Comments

-

<br>


## 관련 이슈

- Close #132 

<br>
