### PR TITLE
Bug/remote fix#138

### DIFF
--- a/b_end/src/mqtt/mqtt.service.ts
+++ b/b_end/src/mqtt/mqtt.service.ts
@@ -53,7 +53,7 @@ export class MqttService implements OnModuleInit {
   }
   remoteDevice(topic: string, msg: string) {
     //  아두이노는 너무 잘 끊겨서 qos 1로 함. retain 옵션으로 다시 구독하는 순간에 해당 메세지 전송받음
-    this.client.publish(topic, msg, { qos: 1, retain: true }, (e) => {
+    this.client.publish(topic, msg, { qos: 1, retain: false }, (e) => {
       if (e) throw new HttpException('Mqtt Error', HttpStatus.BAD_GATEWAY);
     });
   }

--- a/mosqt/mosquitto.conf
+++ b/mosqt/mosquitto.conf
@@ -10,7 +10,11 @@ protocol mqtt
 
 # stdout 출력
 log_dest stdout
-log_type all
+log_type error
+log_type warning
+
+# Connection Log
+connection_messages true
 
 # 보안 설정 (옵션)
 allow_anonymous true


### PR DESCRIPTION
## Summary

- 리모트 버튼이 한 번만 전송되도록 함

<br>

## Description

- Qos 2를 적용할까 고민했지만, 기기가 아닌 브로커에 보내는데다 Qos2를 적용해 생기는 병목이 더 클것이라 판단해 retain만 false로 수정

<br>

## Comments

-

<br>


## 관련 이슈

- Close #138 

<br>
